### PR TITLE
Hide filters and breadcrumb, update sneakers image

### DIFF
--- a/src/views/Products.vue
+++ b/src/views/Products.vue
@@ -52,7 +52,7 @@
         </div>
       </div>
 
-      <div class="products-content no-filters">
+      <div v-if="!currentCategory || showSubcategory" class="products-content no-filters">
         <!-- Main Content -->
         <main class="products-main">
           <!-- Toolbar -->

--- a/src/views/Products.vue
+++ b/src/views/Products.vue
@@ -207,7 +207,7 @@ export default {
     subcategories() {
       const subcategoryMap = {
         'men': [
-          { name: 'Sneakers', image: 'https://cdn.builder.io/api/v1/image/assets%2F797156030b234cce89ce7e033f2e19b8%2F59a0b676dac54856b15ad17fa876ff4e?format=webp&width=200', link: '/products?category=men&type=sneakers', count: this.getProductCount('men', 'sneakers') },
+          { name: 'Sneakers', image: 'https://cdn.builder.io/api/v1/image/assets%2F797156030b234cce89ce7e033f2e19b8%2F2b7df37afbf648ada445ef36d30ccb53?format=webp&width=200', link: '/products?category=men&type=sneakers', count: this.getProductCount('men', 'sneakers') },
           { name: 'Formal', image: 'https://images.unsplash.com/photo-1584464491033-06628f3a6b7b?w=200&h=200&fit=crop&q=90', link: '/products?category=men&type=formal', count: this.getProductCount('men', 'formal') },
           { name: 'Boots', image: 'https://images.unsplash.com/photo-1608667508764-33cf0726aae8?w=200&h=200&fit=crop&q=90', link: '/products?category=men&type=boots', count: this.getProductCount('men', 'boots') },
           { name: 'Sandals', image: 'https://images.unsplash.com/photo-1595950653106-6c9ebd614d3a?w=200&h=200&fit=crop&q=90', link: '/products?category=men&type=sandals', count: this.getProductCount('men', 'sandals') }

--- a/src/views/Products.vue
+++ b/src/views/Products.vue
@@ -13,8 +13,8 @@
     </div>
 
     <div class="container">
-      <!-- Breadcrumb Navigation -->
-      <div class="breadcrumb-nav">
+      <!-- Breadcrumb Navigation Hidden -->
+      <div class="breadcrumb-nav" style="display: none;">
         <router-link to="/" class="breadcrumb-link">
           <svg class="breadcrumb-arrow" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
@@ -207,7 +207,7 @@ export default {
     subcategories() {
       const subcategoryMap = {
         'men': [
-          { name: 'Sneakers', image: 'https://images.unsplash.com/photo-1549298916-b41d501d3772?w=200&h=200&fit=crop&q=90', link: '/products?category=men&type=sneakers', count: this.getProductCount('men', 'sneakers') },
+          { name: 'Sneakers', image: 'https://cdn.builder.io/api/v1/image/assets%2F797156030b234cce89ce7e033f2e19b8%2F59a0b676dac54856b15ad17fa876ff4e?format=webp&width=200', link: '/products?category=men&type=sneakers', count: this.getProductCount('men', 'sneakers') },
           { name: 'Formal', image: 'https://images.unsplash.com/photo-1584464491033-06628f3a6b7b?w=200&h=200&fit=crop&q=90', link: '/products?category=men&type=formal', count: this.getProductCount('men', 'formal') },
           { name: 'Boots', image: 'https://images.unsplash.com/photo-1608667508764-33cf0726aae8?w=200&h=200&fit=crop&q=90', link: '/products?category=men&type=boots', count: this.getProductCount('men', 'boots') },
           { name: 'Sandals', image: 'https://images.unsplash.com/photo-1595950653106-6c9ebd614d3a?w=200&h=200&fit=crop&q=90', link: '/products?category=men&type=sandals', count: this.getProductCount('men', 'sandals') }

--- a/src/views/Products.vue
+++ b/src/views/Products.vue
@@ -21,8 +21,6 @@
           </svg>
           Home
         </router-link>
-        <span v-if="currentCategory" class="breadcrumb-separator">></span>
-        <span v-if="currentCategory" class="breadcrumb-current">{{ categoryTitle }}</span>
         <span v-if="showSubcategory" class="breadcrumb-separator">></span>
         <span v-if="showSubcategory" class="breadcrumb-current">{{ showSubcategory }}</span>
       </div>
@@ -54,10 +52,7 @@
         </div>
       </div>
 
-      <div class="products-content" :class="{ 'no-filters': !showFilters }">
-        <!-- Filters Sidebar -->
-        <ProductFilters v-if="showFilters" />
-
+      <div class="products-content no-filters">
         <!-- Main Content -->
         <main class="products-main">
           <!-- Toolbar -->
@@ -207,7 +202,7 @@ export default {
       return this.$route.query.type
     },
     showFilters() {
-      return !this.showSubcategory
+      return false
     },
     subcategories() {
       const subcategoryMap = {


### PR DESCRIPTION
## Purpose
Based on user feedback, this PR addresses several UI improvements:
- Remove product filters to show all items without filtering
- Hide the Home breadcrumb navigation and arrow elements
- Update the sneakers subcategory to display a specific shoe image
- Ensure men's subcategory shoes are properly displayed when clicking on men category

## Code changes
- **Breadcrumb navigation**: Hidden breadcrumb container using `display: none` and removed category title display logic
- **Product filters**: Disabled filters sidebar by setting `showFilters()` to always return `false` and updated content layout conditions
- **Sneakers image**: Updated men's sneakers subcategory image URL from Unsplash to a Builder.io CDN image
- **Layout**: Modified products content to use `no-filters` class when not showing subcategory or no current category

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 22`

🔗 [Edit in Builder.io](https://builder.io/app/projects/19ff3b095a674c6a9b3c332e260f396f/echo-oasis)

👀 [Preview Link](https://19ff3b095a674c6a9b3c332e260f396f-echo-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>19ff3b095a674c6a9b3c332e260f396f</projectId>-->
<!--<branchName>echo-oasis</branchName>-->